### PR TITLE
Cross-link the Interior Encounter table to bestiary entries

### DIFF
--- a/regions/the-interior.md
+++ b/regions/the-interior.md
@@ -93,26 +93,26 @@ When camping in the desert, the PCs may elect a party member to take watch. Whoe
 ## Desert Encounters
 <table>
 <thead><tr><th>d20</th><th>Encounter</th><th>Terrain</th><th>Behaviour</th></th></thead>
-<tr><td>1</td><td>Yurling</td><td>Scrubby Bushes</td><td>Sleeping</td></tr>
-<tr><td>2</td><td>Thunderstrike Bird</td><td>Salt Pan</td><td>Dying</td></tr>
-<tr><td>3</td><td>Battle Boar</td><td>Sand Dunes</td><td>Patrolling</td></tr>
-<tr><td>4</td><td>Blue Baboon</td><td>Heavy Scree</td><td>Mating</td></tr>
-<tr><td>5</td><td>Giant Azure Scorpion</td><td>Dried Up Stream</td><td>Territorial Display</td></tr>
-<tr><td>6</td><td>Lizard Lion</td><td>Dry Watering Hole</td><td>Eating</td></tr>
-<tr><td>7</td><td>Glass Tiger</td><td>Large Rock</td><td>Relaxing / Nesting</td></tr>
-<tr><td>8</td><td>Greenguard</td><td>Cactus Field</td><td>Pursuit / Fleeing</td></tr>
-<tr><td>9</td><td>Grey Locust</td><td>Grove of Martyr Trees</td><td>Scavenging</td></tr>
-<tr><td>10</td><td>Doppelgeller</td><td>Derelict Vehicle</td><td>Wounded</td></tr>
-<tr><td>11</td><td>Leopard Worm</td><td>Wrecked Spacecraft</td><td>Wounded</td></tr>
-<tr><td>12</td><td>Indigo Servitor</td><td>Abandoned Town</td><td>Travelling</td></tr>
-<tr><td>13</td><td>Bandit</td><td>Ruined Bell-tower</td><td>Psychedelic State</td></tr>
-<tr><td>14</td><td>Pthalo-Jackal</td><td>Toxin Pools</td><td>Sheltering / Hiding</td></tr>
-<tr><td>15</td><td>Planeyfolk</td><td>Caustic Geyser</td><td rowspan="6">Combat with another creature<br />(roll again)</td></tr>
-<tr><td>16</td><td>Regenerator</td><td>Crystalline Growths</td></tr>
-<tr><td>17</td><td>Tiger Fly</td><td>Ancient Battlefield</td></tr>
-<tr><td>18</td><td>Stumbling Drone</td><td>Fungus-choked Outpost</td></tr>
-<tr><td>19</td><td>Alzabo</td><td>Silent Machinery</td></tr>
-<tr><td>20</td><td>Cacogen Pseudo-giant</td><td>Abandoned Campsite</td></tr>
+<tr><td>1</td><td><a href="#/bestiary?id=yurling">Yurling</a></td><td>Scrubby Bushes</td><td>Sleeping</td></tr>
+<tr><td>2</td><td><a href="#/bestiary?id=thunderstrike-bird">Thunderstrike Bird</a></td><td>Salt Pan</td><td>Dying</td></tr>
+<tr><td>3</td><td><a href="#/bestiary?id=battle-boar">Battle Boar</a></td><td>Sand Dunes</td><td>Patrolling</td></tr>
+<tr><td>4</td><td><a href="#/bestiary?id=blue-baboon">Blue Baboon</a></td><td>Heavy Scree</td><td>Mating</td></tr>
+<tr><td>5</td><td><a href="#/bestiary?id=giant-azure-scorpion">Giant Azure Scorpion</a></td><td>Dried Up Stream</td><td>Territorial Display</td></tr>
+<tr><td>6</td><td><a href="#/bestiary?id=lizard-lion">Lizard Lion</a></td><td>Dry Watering Hole</td><td>Eating</td></tr>
+<tr><td>7</td><td><a href="#/bestiary?id=glass-tiger">Glass Tiger</a></td><td>Large Rock</td><td>Relaxing / Nesting</td></tr>
+<tr><td>8</td><td><a href="#/bestiary?id=greenguard">Greenguard</a></td><td>Cactus Field</td><td>Pursuit / Fleeing</td></tr>
+<tr><td>9</td><td><a href="#/bestiary?id=grey-cricket">Grey Cricket</a></td><td>Grove of Martyr Trees</td><td>Scavenging</td></tr>
+<tr><td>10</td><td><a href="#/bestiary?id=doppelgeller">Doppelgeller</a></td><td>Derelict Vehicle</td><td>Wounded</td></tr>
+<tr><td>11</td><td><a href="#/bestiary?id=leopard-worm">Leopard Worm</a></td><td>Wrecked Spacecraft</td><td>Wounded</td></tr>
+<tr><td>12</td><td><a href="#/bestiary?id=indigo-servitor">Indigo Servitor</a></td><td>Abandoned Town</td><td>Travelling</td></tr>
+<tr><td>13</td><td><a href="#/bestiary?id=bandit">Bandit</a></td><td>Ruined Bell-tower</td><td>Psychedelic State</td></tr>
+<tr><td>14</td><td><a href="#/bestiary?id=phthalo-jackal">Phthalo-Jackal</a></td><td>Toxin Pools</td><td>Sheltering / Hiding</td></tr>
+<tr><td>15</td><td><a href="#/bestiary?id=planeyfolk">Planeyfolk</a></td><td>Caustic Geyser</td><td rowspan="6">Combat with another creature<br />(roll again)</td></tr>
+<tr><td>16</td><td><a href="#/bestiary?id=regenerator">Regenerator</a></td><td>Crystalline Growths</td></tr>
+<tr><td>17</td><td><a href="#/bestiary?id=tiger-fly">Tiger Fly</a></td><td>Ancient Battlefield</td></tr>
+<tr><td>18</td><td><a href="#/bestiary?id=stumbling-drone">Stumbling Drone</a></td><td>Fungus-choked Outpost</td></tr>
+<tr><td>19</td><td><a href="#/bestiary?id=alzabo">Alzabo</a></td><td>Silent Machinery</td></tr>
+<tr><td>20</td><td><a href="#/bestiary?id=cacogen-pseudo-giant">Cacogen Pseudo-giant</a></td><td>Abandoned Campsite</td></tr>
 </table>
 
 


### PR DESCRIPTION
I saw @Gulluth had [issue 17](https://github.com/vaarn/vaarn.github.io/issues/17) open, and I had some time. I know @GraculusDroog IRL. I'm not sure if the change from Locust to Cricket is correct, but the bestiary displays it as Cricket. Also changed 'Pthalo-Jackal' to 'Phthalo-Jackal' in the text. Also didn't know what was correct on that. 