### PR TITLE
Add language selection to the SRD

### DIFF
--- a/_navbar.md
+++ b/_navbar.md
@@ -1,0 +1,3 @@
+- Translations
+    - [:uk: English](/)
+    - [:kr: 한국어](/ko/)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,4 +1,3 @@
-- [Home](/)
 - [What is Vaarn?](what-is-vaarn.md)
 - [Creating Characters](creating-characters.md)
   - [Ancestries](ancestries.md)

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       // Translation aliases are defined using the short i18n codes found at https://i18ns.com/languagecode.html
       alias: {
         '/.*/_navbar.md': '/_navbar.md',
-        '/ko/(.*)': 'https://raw.githubusercontent.com/VedminStuden/vaarn-ko/ko/testing/$1',
+        '/ko/(.*)': 'https://raw.githubusercontent.com/VedminStuden/vaarn-ko/ko/testin/$1',
       },
       auto2top: true,
       executeScript: true,
@@ -52,7 +52,7 @@
       paths: 'auto',
       pathNamespaces: ['/ko'],
       search: {
-        paths: auto,
+        paths: 'auto',
         placeholder: {
           '/ko/': '검색',
           '/': 'Type to search',

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     }
 
     // Docsify configuration
+    // Documentation: https://docsify.js.org/#/configuration
     window.$docsify = {
       // Translation aliases are defined using the short i18n codes found at https://i18ns.com/languagecode.html
       alias: {
@@ -32,6 +33,7 @@
       loadFooter: true,
       loadSidebar: true,
       loadNavbar: true,
+      mergeNavbar: true,
       name: 'VAULTS OF VAARN',
       nameLink: {
         '/ko/': '#/ko/',
@@ -49,8 +51,6 @@
           '/': 'PREVIOUS',
         },
       },
-      paths: 'auto',
-      pathNamespaces: ['/ko'],
       search: {
         paths: 'auto',
         placeholder: {
@@ -62,7 +62,6 @@
           '/': 'No Results',
         },
       },
-      sidebarDisplayLevel: 1,
       subMaxLevel: 2,
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
           '/': 'NEXT',
         },
         previousText: {
-          '/ko/': '이전의',
+          '/ko/': '이전',
           '/': 'PREVIOUS',
         },
       },

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       // Translation aliases are defined using the short i18n codes found at https://i18ns.com/languagecode.html
       alias: {
         '/.*/_navbar.md': '/_navbar.md',
-        '/ko/(.*)': 'https://raw.githubusercontent.com/VedminStuden/vaarn-ko/master/$1',
+        '/ko/(.*)': 'https://raw.githubusercontent.com/VedminStuden/vaarn-ko/ko/testing/$1',
       },
       auto2top: true,
       executeScript: true,
@@ -50,12 +50,18 @@
         },
       },
       paths: 'auto',
-      placeholder: {
-        '/ko/': '검색',
-        '/': 'Search',
-      },
       pathNamespaces: ['/ko'],
-      search: 'auto',
+      search: {
+        paths: auto,
+        placeholder: {
+          '/ko/': '검색',
+          '/': 'Type to search',
+        },
+        noData: {
+          '/ko/': '결과 없음',
+          '/': 'No Results',
+        },
+      },
       sidebarDisplayLevel: 1,
       subMaxLevel: 2,
     }

--- a/index.html
+++ b/index.html
@@ -13,25 +13,60 @@
 <body>
   <div id="app"></div>
   <script>
+    // Set html "lang" attribute based on URL
+    var lang = location.hash.match(/#\/(ko)\//);
+
+    if (lang) {
+      document.documentElement.setAttribute('lang', lang[1]);
+    }
+
+    // Docsify configuration
     window.$docsify = {
-      name: 'VAULTS OF VAARN',
+      // Translation aliases are defined using the short i18n codes found at https://i18ns.com/languagecode.html
+      alias: {
+        '/.*/_navbar.md': '/_navbar.md',
+        '/ko/(.*)': 'https://raw.githubusercontent.com/VedminStuden/vaarn-ko/master/$1',
+      },
       auto2top: true,
-      loadFooter: '_footer.md',
+      executeScript: true,
+      loadFooter: true,
       loadSidebar: true,
-      subMaxLevel: 2,
-      sidebarDisplayLevel: 1,
+      loadNavbar: true,
+      name: 'VAULTS OF VAARN',
+      nameLink: {
+        '/ko/': '#/ko/',
+        '/': '#/',
+      },
       pagination: {
         crossChapter: true,
-        crossChapterText: true
+        crossChapterText: true,
+        nextText: {
+          '/ko/': '다음',
+          '/': 'NEXT',
+        },
+        previousText: {
+          '/ko/': '이전의',
+          '/': 'PREVIOUS',
+        },
       },
+      paths: 'auto',
+      placeholder: {
+        '/ko/': '검색',
+        '/': 'Search',
+      },
+      pathNamespaces: ['/ko'],
       search: 'auto',
+      sidebarDisplayLevel: 1,
+      subMaxLevel: 2,
     }
   </script>
-  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
 
-  <!-- plugins -->
+  <!-- load docsify -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+  <!-- load docsify plugins -->
   <script src="//cdn.jsdelivr.net/npm/@alertbox/docsify-footer@1.0.0-0/dist/docsify-footer.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Adds language support to resolve #24 

The Korean translation has been updated to use the language routes defined in the PR. There is still work to update the links, but I thought it would be helpful to have this merged for translation testing.

For the Korean translation, all <a> links should be prefixed with '/ko/' for the new routes in docsify.

